### PR TITLE
Seperate render and logic transform position

### DIFF
--- a/StortSpelProjekt/Engine/src/ECS/Components/CameraComponent.cpp
+++ b/StortSpelProjekt/Engine/src/ECS/Components/CameraComponent.cpp
@@ -42,7 +42,7 @@ namespace component
 		return m_PrimaryCamera;
 	}
 
-	void CameraComponent::Update(double dt)
+	void CameraComponent::RenderUpdate(double dt)
 	{
 		m_pCamera->Update(dt);
 	}

--- a/StortSpelProjekt/Engine/src/ECS/Components/CameraComponent.h
+++ b/StortSpelProjekt/Engine/src/ECS/Components/CameraComponent.h
@@ -18,7 +18,7 @@ namespace component
 		BaseCamera* GetCamera() const;
 		bool IsPrimary() const;
 
-		void Update(double dt);
+		void RenderUpdate(double dt);
 
 	private:
 		BaseCamera* m_pCamera = nullptr;

--- a/StortSpelProjekt/Engine/src/ECS/Components/InputComponent.h
+++ b/StortSpelProjekt/Engine/src/ECS/Components/InputComponent.h
@@ -21,7 +21,7 @@ namespace component
 
 		virtual void Init() = 0;
 
-		virtual void Update(double dt) = 0;
+		virtual void RenderUpdate(double dt) = 0;
 
 	};
 }

--- a/StortSpelProjekt/Engine/src/ECS/Components/TransformComponent.cpp
+++ b/StortSpelProjekt/Engine/src/ECS/Components/TransformComponent.cpp
@@ -19,14 +19,13 @@ namespace component
 	void TransformComponent::Update(double dt)
 	{
 		m_pTransform->Move(dt);
-		m_pTransform->UpdateWorldMatrix();
 	}
 
-	//void TransformComponent::RenderUpdate(double dt)
-	//{
-	//	m_pTransform->MoveRender(dt);
-	//	m_pTransform->UpdateWorldMatrix();
-	//}
+	void TransformComponent::RenderUpdate(double dt)
+	{
+		m_pTransform->MoveRender(dt);
+		m_pTransform->UpdateWorldMatrix();
+	}
 
 	Transform* TransformComponent::GetTransform() const
 	{

--- a/StortSpelProjekt/Engine/src/ECS/Components/TransformComponent.h
+++ b/StortSpelProjekt/Engine/src/ECS/Components/TransformComponent.h
@@ -14,7 +14,7 @@ namespace component
         virtual ~TransformComponent();
 
         void Update(double dt);
-        //void RenderUpdate(double dt);
+        void RenderUpdate(double dt);
 
         Transform* GetTransform() const;
     private:

--- a/StortSpelProjekt/Engine/src/Renderer/Transform.cpp
+++ b/StortSpelProjekt/Engine/src/Renderer/Transform.cpp
@@ -4,6 +4,7 @@
 Transform::Transform()
 {
 	m_Position = DirectX::XMFLOAT3(0.0, 0.0, 0.0);
+	m_RenderPosition = DirectX::XMFLOAT3(0.0, 0.0, 0.0);
 	m_RotationMat = DirectX::XMMatrixIdentity();
 	m_Scale = DirectX::XMFLOAT3(1.0, 1.0, 1.0);
 	m_Movement = DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f);
@@ -142,6 +143,20 @@ float3 Transform::GetPositionFloat3() const
 	pos.x = m_Position.x;
 	pos.y = m_Position.y;
 	pos.z = m_Position.z;
+	return pos;
+}
+
+DirectX::XMFLOAT3 Transform::GetRenderPositionXMFLOAT3() const
+{
+	return m_RenderPosition;
+}
+
+float3 Transform::GetRenderPositionFloat3() const
+{
+	float3 pos = {};
+	pos.x = m_RenderPosition.x;
+	pos.y = m_RenderPosition.y;
+	pos.z = m_RenderPosition.z;
 	return pos;
 }
 

--- a/StortSpelProjekt/Engine/src/Renderer/Transform.cpp
+++ b/StortSpelProjekt/Engine/src/Renderer/Transform.cpp
@@ -56,6 +56,7 @@ void Transform::Move(float dt)
 	float moveZ = m_Position.z + (normalizedMovement.z * 10 * dt);
 
 	m_Position = DirectX::XMFLOAT3(moveX, moveY, moveZ);
+	m_RenderPosition = m_Position;
 }
 
 void Transform::MoveRender(float dt)
@@ -69,7 +70,7 @@ void Transform::MoveRender(float dt)
 	float moveY = m_RenderPosition.y + (normalizedMovement.y * 10 * dt);
 	float moveZ = m_RenderPosition.z + (normalizedMovement.z * 10 * dt);
 
-	m_Position = DirectX::XMFLOAT3(moveX, moveY, moveZ);
+	m_RenderPosition = DirectX::XMFLOAT3(moveX, moveY, moveZ);
 }
 
 void Transform::SetRotationX(float radians)
@@ -109,7 +110,7 @@ void Transform::IncreaseScaleByPercent(float scale)
 
 void Transform::UpdateWorldMatrix()
 {
-	DirectX::XMMATRIX posMat = DirectX::XMMatrixTranslation(m_Position.x, m_Position.y, m_Position.z);
+	DirectX::XMMATRIX posMat = DirectX::XMMatrixTranslation(m_RenderPosition.x, m_RenderPosition.y, m_RenderPosition.z);
 	DirectX::XMMATRIX sclMat = DirectX::XMMatrixScaling(m_Scale.x, m_Scale.y, m_Scale.z);
 	DirectX::XMMATRIX rotMat = m_RotationMat;
 

--- a/StortSpelProjekt/Engine/src/Renderer/Transform.h
+++ b/StortSpelProjekt/Engine/src/Renderer/Transform.h
@@ -34,6 +34,8 @@ public:
 
 	DirectX::XMFLOAT3 GetPositionXMFLOAT3() const;
 	float3 GetPositionFloat3() const;
+	DirectX::XMFLOAT3 GetRenderPositionXMFLOAT3() const;
+	float3 GetRenderPositionFloat3() const;
 	DirectX::XMFLOAT3 GetScale() const;
 	// gets the rotation of the transform in all axisis
 	DirectX::XMMATRIX GetRotMatrix() const;

--- a/StortSpelProjekt/Game/src/PlayerInputComponent.cpp
+++ b/StortSpelProjekt/Game/src/PlayerInputComponent.cpp
@@ -34,7 +34,7 @@ void component::PlayerInputComponent::Init()
 	m_pTransform = static_cast<Transform*>(m_pParent->GetComponent<component::TransformComponent>()->GetTransform());
 }
 
-void component::PlayerInputComponent::Update(double dt)
+void component::PlayerInputComponent::RenderUpdate(double dt)
 {
 	// Lock camera to player
 	if (m_CameraFlags & CAMERA_FLAGS::USE_PLAYER_POSITION)

--- a/StortSpelProjekt/Game/src/PlayerInputComponent.h
+++ b/StortSpelProjekt/Game/src/PlayerInputComponent.h
@@ -30,7 +30,7 @@ namespace component
 
 		void Init();
 
-		void Update(double dt);
+		void RenderUpdate(double dt);
 
 	private:
 		unsigned int m_CameraFlags = 0;

--- a/StortSpelProjekt/Game/src/main.cpp
+++ b/StortSpelProjekt/Game/src/main.cpp
@@ -10,6 +10,10 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
     Engine engine;
     engine.Init(hInstance, nCmdShow);
 
+    /*------ Load Option Variables ------*/
+    Option::GetInstance().ReadFile();
+    float updateRate = 1.0f / Option::GetInstance().GetVariable("updateRate");
+
 	/*  ------ Get references from engine  ------ */
 	Window* const window = engine.GetWindow();
 	Timer* const timer = engine.GetTimer();
@@ -19,6 +23,8 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 
     sceneManager->SetSceneToDraw(GetDemoScene(sceneManager));
 
+    double logicTimer = 0;
+
     if (renderer->GetActiveScene())
     {
         while (!window->ExitWindow())
@@ -27,7 +33,15 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 
             /* ------ Update ------ */
             timer->Update();
-            renderer->Update(timer->GetDeltaTime());
+            logicTimer += timer->GetDeltaTime();
+
+            renderer->RenderUpdate(timer->GetDeltaTime());
+            if (logicTimer >= updateRate)
+            {
+                logicTimer = 0;
+                renderer->Update(updateRate);
+            }
+
             Physics::GetInstance().Update(timer->GetDeltaTime());
             /* ------ Sort ------ */
             renderer->SortObjects();

--- a/StortSpelProjekt/Sandbox/src/PlayerInputComponent.cpp
+++ b/StortSpelProjekt/Sandbox/src/PlayerInputComponent.cpp
@@ -34,13 +34,13 @@ void component::PlayerInputComponent::Init()
 	m_pTransform = static_cast<Transform*>(m_pParent->GetComponent<component::TransformComponent>()->GetTransform());
 }
 
-void component::PlayerInputComponent::Update(double dt)
+void component::PlayerInputComponent::RenderUpdate(double dt)
 {
 	// Lock camera to player
 	if (m_CameraFlags & CAMERA_FLAGS::USE_PLAYER_POSITION)
 	{
 		Transform* tc = m_pParent->GetComponent<TransformComponent>()->GetTransform();
-		float3 playerPosition = tc->GetPositionFloat3();
+		float3 playerPosition = tc->GetRenderPositionFloat3();
 
 		DirectX::XMMATRIX rotMat = tc->GetRotMatrix();
 		DirectX::XMFLOAT3 forward, right;

--- a/StortSpelProjekt/Sandbox/src/PlayerInputComponent.h
+++ b/StortSpelProjekt/Sandbox/src/PlayerInputComponent.h
@@ -29,7 +29,7 @@ namespace component
 
 		void Init();
 
-		void Update(double dt);
+		void RenderUpdate(double dt);
 
 	private:
 		unsigned int m_CameraFlags = 0;

--- a/StortSpelProjekt/Sandbox/src/main.cpp
+++ b/StortSpelProjekt/Sandbox/src/main.cpp
@@ -47,13 +47,13 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
         timer->Update();
         logicTimer += timer->GetDeltaTime();
 
+        renderer->RenderUpdate(timer->GetDeltaTime());
         if (logicTimer >= updateRate)
         {
             logicTimer = 0;
             physics->Update(updateRate);
             renderer->Update(updateRate);
         }
-        renderer->RenderUpdate(timer->GetDeltaTime());
 
         /* ------ Sort ------ */
         renderer->SortObjects();
@@ -777,8 +777,8 @@ Scene* BjornsTestScene(SceneManager* sm)
 
     Entity* entity = scene->AddEntity("player");
     mc = entity->AddComponent<component::ModelComponent>();
-    component::PlayerInputComponent* ic = entity->AddComponent<component::PlayerInputComponent>(CAMERA_FLAGS::USE_PLAYER_POSITION);
     tc = entity->AddComponent<component::TransformComponent>();
+    component::PlayerInputComponent* ic = entity->AddComponent<component::PlayerInputComponent>(CAMERA_FLAGS::USE_PLAYER_POSITION);
     cc = entity->AddComponent<component::CameraComponent>(CAMERA_TYPE::PERSPECTIVE, true);
     ic->Init();
     // adding OBB with collision


### PR DESCRIPTION
Components now use RenderUpdate for variable timestep and Update for fixed timestep

Transform contain a RenderPosition that is updated every frame and used for rendering and camera.
Position is updated 30 times a second and used for physics and logic.