### PR TITLE
Tweak projectile speed

### DIFF
--- a/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/UpgradeRangeVelocity.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/UpgradeRangeVelocity.cpp
@@ -40,7 +40,7 @@ void UpgradeRangeVelocity::ApplyBoughtUpgrade()
 {
 	// get current velocity
 	float currentVelocity = m_pParentEntity->GetComponent<component::RangeComponent>()->GetVelocity();
-	// double the velocity of the shots
+	// increase velocity with 10
 	float newVelocity = currentVelocity + 10;
 	m_pParentEntity->GetComponent<component::RangeComponent>()->SetVelocity(newVelocity);
 

--- a/StortSpelProjekt/Game/src/main.cpp
+++ b/StortSpelProjekt/Game/src/main.cpp
@@ -176,7 +176,9 @@ Scene* GameScene(SceneManager* sm)
     alc = entity->AddComponent<component::Audio3DListenerComponent>();
     bbc = entity->AddComponent<component::BoundingBoxComponent>();
     melc = entity->AddComponent<component::MeleeComponent>();
-    ranc = entity->AddComponent<component::RangeComponent>(sm, scene, sphereModel, 0.2, 1, 50);
+    // range damage should be at least 10 for ranged life steal upgrade to work
+    // range velocity should be 50, otherwise range velocity upgrade does not make sense (may be scrapped later)
+    ranc = entity->AddComponent<component::RangeComponent>(sm, scene, sphereModel, 0.2, 10, 50);
     currc = entity->AddComponent<component::CurrencyComponent>();
     hc = entity->AddComponent<component::HealthComponent>(10000);
     uc = entity->AddComponent<component::UpgradeComponent>();


### PR DESCRIPTION
Set the projectile velocity to start at 50, so that ranged velocity upgrade can be upgraded 5 times to max velocity 100.
Also changed ranged damage to 10 for ranged life steal to get at least 1 hp as lifesteal per hit.