### PR TITLE
Player health tweak

### DIFF
--- a/StortSpelProjekt/Game/src/main.cpp
+++ b/StortSpelProjekt/Game/src/main.cpp
@@ -173,7 +173,7 @@ Scene* GameScene(SceneManager* sm)
     // range velocity should be 50, otherwise range velocity upgrade does not make sense (may be scrapped later)
     ranc = entity->AddComponent<component::RangeComponent>(sm, scene, sphereModel, 0.2, 10, 50);
     currc = entity->AddComponent<component::CurrencyComponent>();
-    hc = entity->AddComponent<component::HealthComponent>(100);
+    hc = entity->AddComponent<component::HealthComponent>(50);
     uc = entity->AddComponent<component::UpgradeComponent>();
 
     Player::GetInstance().SetPlayer(entity);


### PR DESCRIPTION
Lowered player hp to 50. With enemy attacks at 10 the player can take 5 hits before death. Might seem kind of low but keep in mind there are three upgrades that either gives more hp, life steal or lower damage taken when under 30% hp. Start low and work your way up! 