### PR TITLE
Git ignore for range enemy model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,4 @@ StortSpelProjekt/Vendor/Resources/Models/Female/
 
 StortSpelProjekt/Vendor/Resources/Models/PlayerHuman/
 
-StortSpelProjekt/Vendor/Resources/Models/Demon/
-
 StortSpelProjekt/Vendor/Resources/Models/IgnoredModels/

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ StortSpelProjekt/Vendor/Resources/Models/Female/
 StortSpelProjekt/Vendor/Resources/Models/PlayerHuman/
 
 StortSpelProjekt/Vendor/Resources/Models/Demon/
+
+StortSpelProjekt/Vendor/Resources/Models/IgnoredModels/

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ StortSpelProjekt/Game/imgui.ini
 StortSpelProjekt/Vendor/Resources/Models/Female/
 
 StortSpelProjekt/Vendor/Resources/Models/PlayerHuman/
+
+StortSpelProjekt/Vendor/Resources/Models/Demon/


### PR DESCRIPTION
Now all models that should be ignored are kept in the new folder "IgnoredModels".

Still retaining the old ignores since we can't have any mistakes happening when people upload stuff from older branches.