### PR TITLE
Dynamic Entity Fix

### DIFF
--- a/StortSpelProjekt/Engine/src/ECS/SceneManager.cpp
+++ b/StortSpelProjekt/Engine/src/ECS/SceneManager.cpp
@@ -228,8 +228,6 @@ void SceneManager::SetScene(Scene* scene)
 	{
 		m_pActiveScene->SetPrimaryCamera(renderer->m_pScenePrimaryCamera);
 	}
-
-	return;
 }
 
 void SceneManager::ResetScene()

--- a/StortSpelProjekt/Engine/src/ECS/SceneManager.cpp
+++ b/StortSpelProjekt/Engine/src/ECS/SceneManager.cpp
@@ -193,6 +193,12 @@ void SceneManager::SetScene(Scene* scene)
 	if (m_pActiveScene != nullptr)
 	{
 		std::map<std::string, Entity*> oldEntities = *m_pActiveScene->GetEntities();
+
+		for (auto const& [entityName, entity] : oldEntities)
+		{
+			entity->OnUnInitScene();
+		}
+
 		for (auto pair : oldEntities)
 		{
 			Entity* ent = pair.second;
@@ -200,11 +206,6 @@ void SceneManager::SetScene(Scene* scene)
 			{
 				m_pActiveScene->RemoveEntity(ent->GetName());
 			}
-		}
-
-		for (auto const& [entityName, entity] : oldEntities)
-		{
-			entity->OnUnInitScene();
 		}
 	}
 

--- a/StortSpelProjekt/Game/src/Gamefiles/Components/RangeComponent.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/Components/RangeComponent.cpp
@@ -145,7 +145,8 @@ void component::RangeComponent::Attack()
 		}
 
 		plc->SetColor({ 3.0f, 0.0f, 0.0f });
-		plc->Update(0);	// Init, so that the light doesn't spawn in origo first frame
+		ent->Update(0);	// Init, so that the light doesn't spawn in origo first frame;
+		tc->RenderUpdate(0);
 
 		// add the entity to the sceneManager so it can be spawned in in run time
 		ent->SetEntityState(true);	// true == dynamic, which means it will be removed when a new scene is set

--- a/StortSpelProjekt/Game/src/Gamefiles/Components/RangeComponent.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/Components/RangeComponent.cpp
@@ -148,7 +148,7 @@ void component::RangeComponent::Attack()
 		plc->Update(0);	// Init, so that the light doesn't spawn in origo first frame
 
 		// add the entity to the sceneManager so it can be spawned in in run time
-		// TODO: add dynamicly correct
+		ent->SetEntityState(true);	// true == dynamic, which means it will be removed when a new scene is set
 		m_pSceneMan->AddEntity(ent, m_pScene);
 
 		m_TimeAccumulator = 0.0;

--- a/StortSpelProjekt/Sandbox/src/main.cpp
+++ b/StortSpelProjekt/Sandbox/src/main.cpp
@@ -53,8 +53,8 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 
     //Scene* jacobScene = JacobsTestScene(sceneManager);
     //Scene* activeScene = jacobScene;
-    //Scene* leoScene = LeosTestScene(sceneManager);
-    //Scene* activeScene = leoScene;
+    Scene* leoScene = LeosTestScene(sceneManager);
+    Scene* activeScene = leoScene;
     //Scene* timScene = TimScene(sceneManager);
     //Scene* activeScene = timScene;
     //Scene* jockeScene = JockesTestScene(sceneManager);
@@ -69,9 +69,8 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
     //Scene* activeScene = antonScene;
     //Scene* andresScene = AndresTestScene(sceneManager);
     //Scene* activeScene = andresScene;
-
-    Scene* filipScene = FloppipTestScene(sceneManager);
-    Scene* activeScene = filipScene;
+    //Scene* filipScene = FloppipTestScene(sceneManager);
+    //Scene* activeScene = filipScene;
 
     // Set scene
     sceneManager->SetScene(activeScene);


### PR DESCRIPTION
Lights will now not spawn from origo when shooting.
Also, if you shot just before you change scene, lights will now get deleted and not be visible in the new scene as it was before (so did a bugfix) :))