### PR TITLE
OnePixelSmaller

### DIFF
--- a/StortSpelProjekt/Engine/src/Renderer/SwapChain.cpp
+++ b/StortSpelProjekt/Engine/src/Renderer/SwapChain.cpp
@@ -36,7 +36,7 @@ SwapChain::SwapChain(
 	int m_ScreenHeight = mi.rcMonitor.bottom - mi.rcMonitor.top;
 
 	// If the chosen resolution is higher than the screen resolution, set the resolution to the screen resolution
-	if (m_ScreenWidth < width || m_ScreenHeight < height)
+	if (m_ScreenWidth <= width || m_ScreenHeight <= height)
 	{
 		m_CurrentModeDescription.Width = m_ScreenWidth - 1;
 		m_CurrentModeDescription.Height = m_ScreenHeight;


### PR DESCRIPTION
Resolution width is now set to one pixel smaller than the screen size if equal to the screen size