### PR TITLE
Spider AI

### DIFF
--- a/StortSpelProjekt/Game/src/Gamefiles/Components/AiComponent.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/Components/AiComponent.cpp
@@ -611,7 +611,11 @@ void component::AiComponent::pathFinding()
 		NavTriangle* targetCircleTriangle = m_pNavMesh->GetTriangle(pointOnCircle);
 		NavTriangle* targetTriangle = m_pNavMesh->GetTriangle(finalTargetPos);
 
-		if (targetCircleTriangle != m_pGoalTriangle && targetCircleTriangle != targetTriangle)
+		if (targetTriangle != m_pGoalTriangle && m_Flags & F_AI_FLAGS::RUSH_PLAYER)
+		{
+			findPathToTargetTriangle();
+		}
+		else if (targetCircleTriangle != m_pGoalTriangle && targetCircleTriangle != targetTriangle && !(m_Flags & F_AI_FLAGS::RUSH_PLAYER))
 		{
 			m_TargetCirclePoint = { -1.0f + static_cast <float> (rand()) / (static_cast <float> (RAND_MAX / (1.0f - (-1.0f)))), 0.0f, -1.0f + static_cast <float> (rand()) / (static_cast <float> (RAND_MAX / (1.0f - (-1.0f)))) };
 			m_TargetCirclePoint.normalize();
@@ -648,13 +652,17 @@ void component::AiComponent::pathFinding()
 		float3 dirToPlayer = m_pTargetTrans->GetPositionFloat3() - m_pParentTrans->GetPositionFloat3();
 		double angle = std::atan2(m_pParentTrans->GetInvDir() * dirToPlayer.x, m_pParentTrans->GetInvDir() * dirToPlayer.z);
 		cc->SetRotation({ 0.0, 1.0, 0.0 }, angle);
-		m_NextTargetPos = pointOnCircle;
-		if (m_DistanceToPlayer <= m_TargetCircleRadius + 0.5)
+		m_NextTargetPos = finalTargetPos;
+		if (!(m_Flags & F_AI_FLAGS::RUSH_PLAYER))
 		{
-			m_TargetCircleRadius -= 1.0f;
-			if (m_TargetCircleRadius <= m_AttackingDistance * 2.0f)
+			m_NextTargetPos = pointOnCircle;
+			if (m_DistanceToPlayer <= m_TargetCircleRadius + 0.5)
 			{
-				m_NextTargetPos = finalTargetPos;
+				m_TargetCircleRadius -= 1.0f;
+				if (m_TargetCircleRadius <= m_AttackingDistance * 2.0f)
+				{
+					m_NextTargetPos = finalTargetPos;
+				}
 			}
 		}
 		m_LastPos = pos;

--- a/StortSpelProjekt/Game/src/Gamefiles/Components/AiComponent.h
+++ b/StortSpelProjekt/Game/src/Gamefiles/Components/AiComponent.h
@@ -18,6 +18,7 @@ enum F_AI_FLAGS
 {
 	CAN_JUMP = BIT(1),
 	CAN_ROLL = BIT(2),
+	RUSH_PLAYER = BIT(3),
 };
 
 struct PathQuad

--- a/StortSpelProjekt/Game/src/main.cpp
+++ b/StortSpelProjekt/Game/src/main.cpp
@@ -279,7 +279,7 @@ Scene* GameScene(SceneManager* sm)
     spider.hp = 5;
     spider.sound3D = L"Bruh";
     spider.compFlags = F_COMP_FLAGS::OBB | F_COMP_FLAGS::CAPSULE_COLLISION;
-    spider.aiFlags = 0;
+    spider.aiFlags = F_AI_FLAGS::RUSH_PLAYER;
     spider.meleeAttackDmg = 2.0f;
     spider.attackInterval = 0.5f;
     spider.attackSpeed = 0.2f;


### PR DESCRIPTION
Added an AI flag, F_AI_FLAGS::RUSH_PLAYER which, if set, makes the enemy rush the player rather than circle her. To test, set this flag in the definition of one of the enemies, e.g. the zombie (as the spider is not yet created by the factory)