### PR TITLE
Fixed shop reset

### DIFF
--- a/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/Upgrade.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/Upgrade.cpp
@@ -88,6 +88,10 @@ void Upgrade::RenderUpdate(double dt)
 void Upgrade::SetLevel(unsigned int lvl)
 {
 	m_Level = lvl;
+	if (lvl == 0)
+	{
+		m_Price = m_StartingPrice;
+	}
 }
 
 

--- a/StortSpelProjekt/Game/src/Gamefiles/Player.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/Player.cpp
@@ -88,4 +88,6 @@ void Player::onResetGame(ResetGame* evnt)
 	SceneManager::GetInstance().GetScene("GameScene")->GetEntity("player")->GetComponent<component::HealthComponent>()->SetMaxHealth(50);
 	SceneManager::GetInstance().GetScene("GameScene")->GetEntity("healthBackground")->GetComponent<component::GUI2DComponent>()->GetTextManager()->SetText("50", "currentHealth");
 	SceneManager::GetInstance().GetScene("GameScene")->GetEntity("healthBackground")->GetComponent<component::GUI2DComponent>()->GetTextManager()->SetText("50", "maxHealth");
+
+	m_pShop->Reset();
 }

--- a/StortSpelProjekt/Game/src/Gamefiles/Shop.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/Shop.cpp
@@ -228,8 +228,8 @@ void Shop::ApplyUppgrade(std::string name)
 		// because we want to increase level of RANGE type upgrades as well and this needs to be done in UpgradeManager.
 		if (m_AllAvailableUpgrades[name]->GetType() & F_UpgradeType::PLAYER)
 		{
-			m_pPlayer->GetComponent<component::UpgradeComponent>()->GetUpgradeByName(name)->IncreaseLevel();
 			m_pPlayer->GetComponent<component::UpgradeComponent>()->GetUpgradeByName(name)->ApplyStat();
+			m_pPlayer->GetComponent<component::UpgradeComponent>()->GetUpgradeByName(name)->IncreaseLevel();
 		}
 		m_pUpgradeManager->IncreaseLevel(name);
 	}


### PR DESCRIPTION
There was a function call missing which would reset the level of the upgrades in the shop. This call was added, and included a reset of the price.
There was also a problem with the order of "apply upgrade" and "increase level" for the upgrades. This was fixed