### PR TITLE
Upgrade Balance and fix

### DIFF
--- a/StortSpelProjekt/Game/src/Gamefiles/Components/HealthComponent.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/Components/HealthComponent.cpp
@@ -139,6 +139,10 @@ void component::HealthComponent::TakeDamage(int damage)
 		m_pParent->GetComponent<component::UpgradeComponent>()->OnDamage();
 	}
 	damage = (damage - m_FlatDamageReduction) * m_MultiplicativeDamageReduction; //Flat Damage gets applied first followed by multaplicative damage
+	if (damage <= 0)
+	{
+		damage = 1;
+	}
 	ChangeHealth(-damage);
 	//Damage reduction stat is reset to allow upgrade to change again
 	m_FlatDamageReduction = 0.0;

--- a/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/UpgradeBlueJewel.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/UpgradeBlueJewel.cpp
@@ -14,7 +14,7 @@ UpgradeBlueJewel::UpgradeBlueJewel(Entity* parentEntity) : Upgrade(parentEntity)
 
 	m_ImageName = "BlueJewel.png";
 	
-	m_StartDamageReduction = 0.25; // 25%
+	m_StartDamageReduction = 0.75; // 25% damage reduction
 	m_DamageReduction = m_StartDamageReduction;
 	m_HealthThreshold = 0.5; // 50%
 }
@@ -28,7 +28,7 @@ void UpgradeBlueJewel::OnDamage()
 {
 	if (m_pParentEntity->GetComponent<component::HealthComponent>()->GetHealth() <= float(m_pParentEntity->GetComponent<component::HealthComponent>()->GetMaxHealth() * m_HealthThreshold))
 	{
-		m_pParentEntity->GetComponent<component::HealthComponent>()->ChangeMultiplicativeDamageReduction(1.0f - m_DamageReduction);
+		m_pParentEntity->GetComponent<component::HealthComponent>()->ChangeMultiplicativeDamageReduction(m_DamageReduction);
 	}
 }
 
@@ -43,5 +43,5 @@ void UpgradeBlueJewel::IncreaseLevel()
 
 std::string UpgradeBlueJewel::GetDescription(unsigned int level)
 {
-	return "Blue Jewel: An iridecent blue jewel that reduces damage taken by " + std::to_string(static_cast<int>(pow(m_StartDamageReduction, level) * 100)) + "\% while under " + std::to_string(static_cast<int>(m_HealthThreshold*100)) + "\% max health";
+	return "Blue Jewel: An iridecent blue jewel that reduces damage taken by " + std::to_string(static_cast<int>(pow(1.0f - m_StartDamageReduction, level) * 100)) + "\% while under " + std::to_string(static_cast<int>(m_HealthThreshold*100)) + "\% max health";
 }

--- a/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/UpgradeBlueJewel.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/UpgradeBlueJewel.cpp
@@ -9,14 +9,14 @@ UpgradeBlueJewel::UpgradeBlueJewel(Entity* parentEntity) : Upgrade(parentEntity)
 	// set the type of the upgrade
 	SetType(F_UpgradeType::PLAYER);
 	// set the price of the upgrade
-	m_Price = 900;
+	m_Price = 200;
 	m_StartingPrice = m_Price;
 
 	m_ImageName = "BlueJewel.png";
 	
-	m_StartDamageReduction = 0.4; // 40%
+	m_StartDamageReduction = 0.25; // 25%
 	m_DamageReduction = m_StartDamageReduction;
-	m_HealthThreshold = 0.3; // 30%
+	m_HealthThreshold = 0.5; // 50%
 }
 
 UpgradeBlueJewel::~UpgradeBlueJewel()
@@ -26,7 +26,7 @@ UpgradeBlueJewel::~UpgradeBlueJewel()
 
 void UpgradeBlueJewel::OnDamage()
 {
-	if (m_pParentEntity->GetComponent<component::HealthComponent>()->GetHealth() <= float(m_pParentEntity->GetComponent<component::HealthComponent>()->GetMaxHealth() * 0.3))
+	if (m_pParentEntity->GetComponent<component::HealthComponent>()->GetHealth() <= float(m_pParentEntity->GetComponent<component::HealthComponent>()->GetMaxHealth() * m_HealthThreshold))
 	{
 		m_pParentEntity->GetComponent<component::HealthComponent>()->ChangeMultiplicativeDamageReduction(m_DamageReduction);
 	}

--- a/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/UpgradeBlueJewel.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/UpgradeBlueJewel.cpp
@@ -43,5 +43,5 @@ void UpgradeBlueJewel::IncreaseLevel()
 
 std::string UpgradeBlueJewel::GetDescription(unsigned int level)
 {
-	return "Blue Jewel: An iridecent blue jewel that reduces damage taken by " + std::to_string(static_cast<int>(pow(1.0f - m_StartDamageReduction, level) * 100)) + "\% while under " + std::to_string(static_cast<int>(m_HealthThreshold*100)) + "\% max health";
+	return "Blue Jewel: An iridecent blue jewel that makes the wearer only take " + std::to_string(static_cast<int>(pow(m_StartDamageReduction, level) * 100)) + "\% of damage taken while under " + std::to_string(static_cast<int>(m_HealthThreshold*100)) + "\% max health";
 }

--- a/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/UpgradeBlueJewel.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/UpgradeBlueJewel.cpp
@@ -28,7 +28,7 @@ void UpgradeBlueJewel::OnDamage()
 {
 	if (m_pParentEntity->GetComponent<component::HealthComponent>()->GetHealth() <= float(m_pParentEntity->GetComponent<component::HealthComponent>()->GetMaxHealth() * m_HealthThreshold))
 	{
-		m_pParentEntity->GetComponent<component::HealthComponent>()->ChangeMultiplicativeDamageReduction(m_DamageReduction);
+		m_pParentEntity->GetComponent<component::HealthComponent>()->ChangeMultiplicativeDamageReduction(1.0f - m_DamageReduction);
 	}
 }
 

--- a/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/UpgradeHealthRegen.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/UpgradeHealthRegen.cpp
@@ -28,7 +28,7 @@ UpgradeHealthRegen::~UpgradeHealthRegen()
 void UpgradeHealthRegen::Update(double dt)
 {
 	//count up the timer until we reach 1 to give one health.
-	//This gives a health regeneration of 4hp per second per level or 1hp every 0.25 seconds per level
+	//This gives a health regeneration of 2hp per second per level or 1hp every 0.50 seconds per level
 	m_HealthTimer += dt * (m_Level * 2);
 	while (m_HealthTimer >= 1)
 	{

--- a/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/UpgradeHealthRegen.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/UpgradeHealthRegen.cpp
@@ -29,7 +29,7 @@ void UpgradeHealthRegen::Update(double dt)
 {
 	//count up the timer until we reach 1 to give one health.
 	//This gives a health regeneration of 4hp per second per level or 1hp every 0.25 seconds per level
-	m_HealthTimer += dt * (m_Level * 4);
+	m_HealthTimer += dt * (m_Level * 2);
 	while (m_HealthTimer >= 1)
 	{
 		m_HealthTimer -= 1;
@@ -47,5 +47,5 @@ void UpgradeHealthRegen::IncreaseLevel()
 
 std::string UpgradeHealthRegen::GetDescription(unsigned int level)
 {
-	return "Health Regeneration: Passively heals the player " + std::to_string(level * 4) + " health point every second";
+	return "Health Regeneration: Passively heals the player " + std::to_string(level * 2) + " health point every second";
 }

--- a/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/UpgradeMeleeRadius.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/UpgradeMeleeRadius.cpp
@@ -9,7 +9,7 @@ UpgradeMeleeRadius::UpgradeMeleeRadius(Entity* parent) : Upgrade(parent)
 	// set the type of the upgrade
 	SetType(F_UpgradeType::PLAYER);
 	// set the price of the upgrade
-	m_Price = 400;
+	m_Price = 250;
 	m_StartingPrice = m_Price;
 	m_MaxLevel = 3;
 

--- a/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/UpgradePoisonAttack.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/UpgradePoisonAttack.cpp
@@ -66,7 +66,7 @@ std::string UpgradePoisonAttack::GetDescription(unsigned int level)
 	std::string str = "Poison Attack: Causes your projectile to apply a poison. Deals ";
 	std::ostringstream damage;
 	damage.precision(2);
-	damage << std::fixed << ((float)(4 + m_Level * 2)) * (9 + level);
+	damage << std::fixed << ((float)(4 + level * 2)) * (9 + level);
 	str += damage.str();
 	str += " damage over ";
 	std::ostringstream duration;
@@ -76,7 +76,7 @@ std::string UpgradePoisonAttack::GetDescription(unsigned int level)
 	str += " seconds and slows the enemy by ";
 	std::ostringstream slow;
 	slow.precision(0);
-	slow << std::fixed << (0.10 + (float)m_Level / 10.0f);
+	slow << std::fixed << ((0.10 + (float)level / 10.0f)*100);
 	str += slow.str();
 	return 	 str + " \%";
 

--- a/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/UpgradePoisonAttack.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/UpgradePoisonAttack.cpp
@@ -19,8 +19,7 @@ UpgradePoisonAttack::UpgradePoisonAttack(Entity* parent)
 
 	m_ImageName = "PoisonAttack.png";
 
-	// percentage of damage done to steal as life
-	m_Damage = 1;
+	m_Damage = 0.04;
 	m_NrOfTicks = 9;
 	m_TickDuration = 0.5;
 	m_Slow = 0.1;
@@ -34,7 +33,7 @@ void UpgradePoisonAttack::IncreaseLevel()
 {
 	m_Level++;
 	m_NrOfTicks = 9 + m_Level;
-	m_Damage = (float)(4 + m_Level*2);
+	m_Damage = (float)(0.04 * m_Level);
 	m_Slow = 0.10 + (float)m_Level / 10.0f;
 	m_Price = m_StartingPrice * (m_Level + 1);
 
@@ -46,11 +45,11 @@ void UpgradePoisonAttack::OnRangedHit(Entity* target, Entity* projectile)
 	{
 		if (target->HasComponent<component::PoisonDebuff>())
 		{
-			target->GetComponent<component::PoisonDebuff>()->Reset(m_Damage, m_NrOfTicks, m_TickDuration, m_Slow);
+			target->GetComponent<component::PoisonDebuff>()->Reset(m_pParentEntity->GetComponent<component::ProjectileComponent>()->GetDamage() * m_Damage, m_NrOfTicks, m_TickDuration, m_Slow);
 		}
 		else
 		{
-			target->AddComponent<component::PoisonDebuff>(m_Damage, m_NrOfTicks, m_TickDuration, m_Slow);
+			target->AddComponent<component::PoisonDebuff>(m_pParentEntity->GetComponent<component::ProjectileComponent>()->GetDamage() * m_Damage, m_NrOfTicks, m_TickDuration, m_Slow);
 		}
 	}
 }
@@ -65,10 +64,10 @@ std::string UpgradePoisonAttack::GetDescription(unsigned int level)
 {
 	std::string str = "Poison Attack: Causes your projectile to apply a poison. Deals ";
 	std::ostringstream damage;
-	damage.precision(2);
-	damage << std::fixed << ((float)(4 + level * 2)) * (9 + level);
+	damage.precision(1);
+	damage << std::fixed << ((0.04 * level * (9 + level))*100);
 	str += damage.str();
-	str += " damage over ";
+	str += "% of range damage over ";
 	std::ostringstream duration;
 	duration.precision(1);
 	duration << std::fixed << (float)(9 + level) * m_TickDuration;

--- a/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/UpgradePoisonAttack.h
+++ b/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/UpgradePoisonAttack.h
@@ -18,7 +18,7 @@ public:
 	std::string GetDescription(unsigned int level);
 
 private:
-	int m_Damage;
+	float m_Damage;
 	int m_NrOfTicks;
 	float m_Slow;
 	double m_TickDuration;

--- a/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/UpgradeRangeDamage.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/UpgradeRangeDamage.cpp
@@ -14,7 +14,7 @@ UpgradeRangeDamage::UpgradeRangeDamage(Entity* parentEntity) : Upgrade(parentEnt
 
 	m_DamageChange = 25;
 
-	m_ImageName = "Rangedamage.png";
+	m_ImageName = "RangeUpgrade.png";
 }
 
 UpgradeRangeDamage::~UpgradeRangeDamage()

--- a/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/UpgradeRangeLifeSteal.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/UpgradeRangeLifeSteal.cpp
@@ -17,6 +17,8 @@ UpgradeRangeLifeSteal::UpgradeRangeLifeSteal(Entity* parent)
 	
 	// percentage of damage done to steal as life
 	m_PercentageGain = 0.10;
+
+	m_ImageName = "RangeUpgrade.png";
 }
 
 UpgradeRangeLifeSteal::~UpgradeRangeLifeSteal()

--- a/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/UpgradeRangeVelocity.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/Components/UpgradeComponents/Upgrades/UpgradeRangeVelocity.cpp
@@ -16,6 +16,8 @@ UpgradeRangeVelocity::UpgradeRangeVelocity(Entity* parent)
 
 	// this upgrade will have a max level
 	m_MaxLevel = 5;
+
+	m_ImageName = "RangeUpgrade.png";
 }
 
 UpgradeRangeVelocity::~UpgradeRangeVelocity()


### PR DESCRIPTION
Blue Jewel: This upgrade is insanely expensive for what it does. It gives 12% more effective health which translates to 60hp without boosters. For 900 curr it is too expensive.
- Damage reduction: 40% -> 25%
- Health Threshold: 30% -> 50%
- Cost: 900 -> 200
It now has 12.5% effective health boost for a lot less cost.

Health Regeneration: It gives way to much health. A round takes about 50-70 seconds early on which translate at 4hp/s to about 200-280 more hp.
- Health Regen: 4 -> 2
It now has a effective health off 100-140 which is more inline with health boost.

Poison Attack: This upgrade had a flat damage over time which is hard to interpert when the player dont know the enemies health or their own damage. Instead it does a procentile amount of range damage over time.
- Damage per tick: 6 -> 4% of range damage
- Damage Scaling: 2 -> 4% of range damage
- Fixed Description
This gives 40% of range damage on first level, 88% on second, 144% on third etc..

Melee Radius: This QoL upgrade is very nice for game feel and shouldn't take the entire first round currency to purchase.
- Cost: 400 -> 250