### PR TITLE
GameOver stats

### DIFF
--- a/StortSpelProjekt/Engine/src/ImGUI/ImGuiHandler.cpp
+++ b/StortSpelProjekt/Engine/src/ImGUI/ImGuiHandler.cpp
@@ -393,6 +393,14 @@ void ImGuiHandler::ExecCommand(const char* command_line)
         Player::GetInstance().GetPlayer()->GetComponent<component::HealthComponent>()->SetMaxHealth(1000000);
         Player::GetInstance().GetPlayer()->GetComponent<component::HealthComponent>()->SetHealth(1000000);
     }
+    else if (Stricmp(command.c_str(), "KILLPLAYER") == 0)
+    {
+        Player::GetInstance().GetPlayer()->GetComponent<component::HealthComponent>()->SetHealth(0);
+    }
+    else if (Stricmp(command.c_str(), "SKIPLEVEL") == 0)
+    {  
+        EventBus::GetInstance().Publish(&LevelDone());
+    }
     else
     {
         AddLog("Unknown command: '%s'\n", command.c_str());
@@ -551,6 +559,8 @@ ImGuiHandler::ImGuiHandler()
     m_Commands.push_back("RESET");
     m_Commands.push_back("HARVEST");
     m_Commands.push_back("GODMODE");
+    m_Commands.push_back("KILLPLAYER");
+    m_Commands.push_back("SKIPLEVEL");
     if (std::atoi(Option::GetInstance().GetVariable("i_network").c_str()) == 1)
     {
         m_Commands.push_back("CONNECT");

--- a/StortSpelProjekt/Game/src/Gamefiles/EnemyFactory.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/EnemyFactory.cpp
@@ -18,6 +18,7 @@ EnemyFactory::EnemyFactory()
 	m_MaxEnemies = 30;
 	m_LevelMaxEnemies = 20;
 	m_EnemiesKilled = 0;
+	m_TotalEnemiesKilled = 0;
 	m_EnemiesToSpawn = 0;
 	m_LevelTime = 30;
 	m_LevelTimer = 0;
@@ -287,6 +288,16 @@ std::vector<Entity*>* EnemyFactory::GetAllEnemies()
 	return &m_Enemies;
 }
 
+int EnemyFactory::GetTotalKilled()
+{
+	return m_TotalEnemiesKilled;
+}
+
+int EnemyFactory::GetLevel()
+{
+	return m_Level;
+}
+
 void EnemyFactory::AddSpawnPoint(const float3& point)
 {
 	m_SpawnPoints.push_back({ point.x, point.y, point.z });
@@ -534,20 +545,24 @@ void EnemyFactory::killRound(double dt)
 void EnemyFactory::enemyDeath(Death* evnt)
 {
 	//We don't care about kills on time rounds
-	if (strcmp(evnt->ent->GetName().substr(0, 5).c_str(), "enemy") == 0 && !m_TimeRound)
+	if (strcmp(evnt->ent->GetName().substr(0, 5).c_str(), "enemy") == 0)
 	{
-		m_EnemiesKilled++;
-
-		Entity* enemyGui = m_pScene->GetEntity("enemyGui");
-		if (enemyGui != nullptr)
+		m_TotalEnemiesKilled++;
+		if (!m_TimeRound)
 		{
-			enemyGui->GetComponent<component::GUI2DComponent>()->GetTextManager()->SetText(std::to_string(m_EnemiesKilled) + "/" + std::to_string(m_LevelMaxEnemies), "enemyGui");
-		}
+			m_EnemiesKilled++;
 
-		//If we have reached the kill goal we are done with the level and should do anything coming from that
-		if (m_EnemiesKilled >= m_LevelMaxEnemies)
-		{
-			EventBus::GetInstance().Publish(&LevelDone());
+			Entity* enemyGui = m_pScene->GetEntity("enemyGui");
+			if (enemyGui != nullptr)
+			{
+				enemyGui->GetComponent<component::GUI2DComponent>()->GetTextManager()->SetText(std::to_string(m_EnemiesKilled) + "/" + std::to_string(m_LevelMaxEnemies), "enemyGui");
+			}
+
+			//If we have reached the kill goal we are done with the level and should do anything coming from that
+			if (m_EnemiesKilled >= m_LevelMaxEnemies)
+			{
+				EventBus::GetInstance().Publish(&LevelDone());
+			}
 		}
 	}
 }
@@ -675,6 +690,7 @@ void EnemyFactory::onRoundStart(RoundStart* evnt)
 void EnemyFactory::onResetGame(ResetGame* evnt)
 {
 	m_Level = 0;
+	m_TotalEnemiesKilled = 0;
 	m_EnemyComps["enemyDemon"]->spawnChance = 0;
 	m_EnemyComps["enemyZombie"]->spawnChance = 0;
 	m_EnemyComps["enemySpider"]->spawnChance = 0;

--- a/StortSpelProjekt/Game/src/Gamefiles/EnemyFactory.h
+++ b/StortSpelProjekt/Game/src/Gamefiles/EnemyFactory.h
@@ -92,6 +92,11 @@ public:
 
 	std::vector<Entity*>* GetAllEnemies();
 	
+	//Gets the total amount of killed enemies during the game
+	int GetTotalKilled();
+	//Gets what level the player is currently on
+	int GetLevel();
+
 	// Adds a spawnpoint.
 	void AddSpawnPoint(const float3& point);
 	void ClearSpawnPoints();
@@ -141,6 +146,7 @@ private:
 	int m_LevelMaxEnemies;
 	int m_EnemySlotsLeft;
 	int m_EnemiesKilled;
+	int m_TotalEnemiesKilled;
 	unsigned int m_Level;
 	float m_SpawnCooldown;
 	float m_SpawnTimer;

--- a/StortSpelProjekt/Game/src/Gamefiles/GameGUI.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/GameGUI.cpp
@@ -12,24 +12,45 @@ GameGUI::GameGUI()
 	m_OldMoney = 0;
 	m_OldHealthLength = 0.0f;
 	m_pOldScene = nullptr;
+	m_TimePlayed = 0;
+	m_TimePlayedTimer = 0;
 }
+
+GameGUI& GameGUI::GetInstance()
+{
+	static GameGUI instance;
+	return instance;
+}
+
 
 void GameGUI::Update(double dt, Scene* scene)
 {
 	updateHealth(scene);
 
-	if (scene->EntityExists("money"))
+	if (scene->GetName() == "GameScene" || scene->GetName() == "ShopScene")
 	{
-		Entity* entity = scene->GetEntity("money");
-		if (entity->HasComponent<component::GUI2DComponent>())
+		//Count up for how long the player has played
+		m_TimePlayedTimer += dt;
+		if (m_TimePlayedTimer >= 1.0)
 		{
-			int money = Player::GetInstance().GetPlayer()->GetComponent<component::CurrencyComponent>()->GetBalace();
-			if (money != m_OldMoney)
+			m_TimePlayedTimer -= 1.0;
+			m_TimePlayed++;
+		}
+
+		//Update Currency
+		if (scene->EntityExists("money"))
+		{
+			Entity* entity = scene->GetEntity("money");
+			if (entity->HasComponent<component::GUI2DComponent>())
 			{
-				entity->GetComponent<component::GUI2DComponent>()->GetTextManager()->SetText(
-					std::to_string(money),
-					"money");
-				m_OldMoney = money;
+				int money = Player::GetInstance().GetPlayer()->GetComponent<component::CurrencyComponent>()->GetBalace();
+				if (money != m_OldMoney)
+				{
+					entity->GetComponent<component::GUI2DComponent>()->GetTextManager()->SetText(
+						std::to_string(money),
+						"money");
+					m_OldMoney = money;
+				}
 			}
 		}
 	}
@@ -51,6 +72,11 @@ void GameGUI::Update(double dt, Scene* scene)
 	}
 
 	m_pOldScene = scene;
+}
+
+int GameGUI::GetTimePlayed()
+{
+	return m_TimePlayed;
 }
 
 void GameGUI::updateHealth(Scene* scene)
@@ -150,4 +176,6 @@ void GameGUI::reset(Scene* scene)
 	m_OldMaxHealth = 0;
 	m_OldMoney = 0;
 	m_OldHealthLength = 0;
+	m_TimePlayed = 0;
+	m_TimePlayedTimer = 0;
 }

--- a/StortSpelProjekt/Game/src/Gamefiles/GameGUI.h
+++ b/StortSpelProjekt/Game/src/Gamefiles/GameGUI.h
@@ -8,11 +8,19 @@
 class GameGUI
 {
 public:
-	GameGUI();
+	static GameGUI& GetInstance();
 
 	void Update(double dt, Scene* scene);
 
+	//Gets for how long the player has played the current round as a whole number
+	int GetTimePlayed();
+
 private:
+	GameGUI();
+
+	int m_TimePlayed; //Holds the time as int to allow higher count and not lose precision with higher count
+	double m_TimePlayedTimer; //Count to 1 to increase TimePlayeds
+
 	int m_OldHealth;
 	int m_OldMaxHealth;
 	int m_OldMoney;

--- a/StortSpelProjekt/Game/src/Gamefiles/GameOverHandler.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/GameOverHandler.cpp
@@ -72,7 +72,7 @@ Scene* GameOverHandler::CreateScene(SceneManager* sm)
     guiComp->GetTextManager()->SetFont(arial);
     guiComp->GetTextManager()->AddText("levelPlayed");
     guiComp->GetTextManager()->SetScale({ 0.6, 0.6 }, "levelPlayed");
-    guiComp->GetTextManager()->SetPos({ 0.35, 0.35 }, "levelPlayed");
+    guiComp->GetTextManager()->SetPos({ 0.405, 0.36 }, "levelPlayed");
     guiComp->GetTextManager()->SetText("Level Reached: ", "levelPlayed");
 
     // KilledEnemies
@@ -81,7 +81,7 @@ Scene* GameOverHandler::CreateScene(SceneManager* sm)
 	guiComp->GetTextManager()->SetFont(arial);
     guiComp->GetTextManager()->AddText("killedEnemies");
     guiComp->GetTextManager()->SetScale({ 0.6, 0.6 }, "killedEnemies");
-    guiComp->GetTextManager()->SetPos({ 0.35, 0.45 }, "killedEnemies");
+    guiComp->GetTextManager()->SetPos({ 0.405, 0.46 }, "killedEnemies");
     guiComp->GetTextManager()->SetText("Enemies Killed: ", "killedEnemies");
 
     // KilledEnemies
@@ -90,7 +90,7 @@ Scene* GameOverHandler::CreateScene(SceneManager* sm)
     guiComp->GetTextManager()->SetFont(arial);
     guiComp->GetTextManager()->AddText("timePlayed");
     guiComp->GetTextManager()->SetScale({ 0.6, 0.6 }, "timePlayed");
-    guiComp->GetTextManager()->SetPos({ 0.35, 0.55 }, "timePlayed");
+    guiComp->GetTextManager()->SetPos({ 0.405, 0.56 }, "timePlayed");
     guiComp->GetTextManager()->SetText("Time Played: ", "timePlayed");
 
 

--- a/StortSpelProjekt/Game/src/Gamefiles/GameOverHandler.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/GameOverHandler.cpp
@@ -7,6 +7,8 @@
 #include "Misc/Option.h"
 #include "Events/EventBus.h"
 #include "Misc/GUI2DElements/Font.h"
+#include "EnemyFactory.h"
+#include "GameGUI.h"
 
 void onGameOverSceneInit(Scene*);
 void onMainMenu(const std::string& name);
@@ -52,17 +54,45 @@ Scene* GameOverHandler::CreateScene(SceneManager* sm)
 	guiComp->GetTextManager()->SetFont(arial);
     guiComp->GetTextManager()->AddText("GameOverText");
     guiComp->GetTextManager()->SetScale({ 2, 2 }, "GameOverText");
-    guiComp->GetTextManager()->SetPos({ 0.29, 0.41 }, "GameOverText");
+    guiComp->GetTextManager()->SetPos({ 0.29, 0.10 }, "GameOverText");
     guiComp->GetTextManager()->SetText("Game Over", "GameOverText");
 
-    // text2
+    // "You Died"
     entity = scene->AddEntity("youDiedText");
     guiComp = entity->AddComponent<component::GUI2DComponent>();
-	guiComp->GetTextManager()->SetFont(arial);
+    guiComp->GetTextManager()->SetFont(arial);
     guiComp->GetTextManager()->AddText("youDiedText");
     guiComp->GetTextManager()->SetScale({ 0.6, 0.6 }, "youDiedText");
-    guiComp->GetTextManager()->SetPos({ 0.43, 0.56 }, "youDiedText");
+    guiComp->GetTextManager()->SetPos({ 0.43, 0.25 }, "youDiedText");
     guiComp->GetTextManager()->SetText("(You Died...)", "youDiedText");
+
+    // Rounds Played
+    entity = scene->AddEntity("levelPlayed");
+    guiComp = entity->AddComponent<component::GUI2DComponent>();
+    guiComp->GetTextManager()->SetFont(arial);
+    guiComp->GetTextManager()->AddText("levelPlayed");
+    guiComp->GetTextManager()->SetScale({ 0.6, 0.6 }, "levelPlayed");
+    guiComp->GetTextManager()->SetPos({ 0.35, 0.35 }, "levelPlayed");
+    guiComp->GetTextManager()->SetText("Level Reached: ", "levelPlayed");
+
+    // KilledEnemies
+    entity = scene->AddEntity("killedEnemies");
+    guiComp = entity->AddComponent<component::GUI2DComponent>();
+	guiComp->GetTextManager()->SetFont(arial);
+    guiComp->GetTextManager()->AddText("killedEnemies");
+    guiComp->GetTextManager()->SetScale({ 0.6, 0.6 }, "killedEnemies");
+    guiComp->GetTextManager()->SetPos({ 0.35, 0.45 }, "killedEnemies");
+    guiComp->GetTextManager()->SetText("Enemies Killed: ", "killedEnemies");
+
+    // KilledEnemies
+    entity = scene->AddEntity("timePlayed");
+    guiComp = entity->AddComponent<component::GUI2DComponent>();
+    guiComp->GetTextManager()->SetFont(arial);
+    guiComp->GetTextManager()->AddText("timePlayed");
+    guiComp->GetTextManager()->SetScale({ 0.6, 0.6 }, "timePlayed");
+    guiComp->GetTextManager()->SetPos({ 0.35, 0.55 }, "timePlayed");
+    guiComp->GetTextManager()->SetText("Time Played: ", "timePlayed");
+
 
 #pragma region ReturnQuad
     entity = scene->AddEntity("MainMenuQuad");
@@ -97,6 +127,12 @@ GameOverHandler::GameOverHandler()
 void onGameOverSceneInit(Scene* scene)
 {
     ShowCursor(true);
+    scene->GetEntity("levelPlayed")->GetComponent<component::GUI2DComponent>()->GetTextManager()->SetText("Level Reached: " + std::to_string(EnemyFactory::GetInstance().GetLevel()), "levelPlayed");
+    scene->GetEntity("killedEnemies")->GetComponent<component::GUI2DComponent>()->GetTextManager()->SetText("Enemies Killed: " + std::to_string(EnemyFactory::GetInstance().GetTotalKilled()), "killedEnemies");
+    int seconds = GameGUI::GetInstance().GetTimePlayed();
+    int minute = seconds / 60;
+    seconds = seconds % 60;
+    scene->GetEntity("timePlayed")->GetComponent<component::GUI2DComponent>()->GetTextManager()->SetText("Time Played: " + std::to_string(minute) + ":" + std::to_string(seconds), "timePlayed");
 }
 
 void onMainMenu(const std::string& name)

--- a/StortSpelProjekt/Game/src/main.cpp
+++ b/StortSpelProjekt/Game/src/main.cpp
@@ -30,8 +30,6 @@ void ParticleInit();
 void GameUpdateScene(SceneManager* sm, double dt);
 void ShopUpdateScene(SceneManager* sm, double dt);
 
-GameGUI gameGUI;
-
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
     _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
@@ -121,7 +119,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
             EnemyFactory::GetInstance().Update(updateRate);
             sceneManager->Update(updateRate);
             physics->Update(updateRate);
-            gameGUI.Update(updateRate, sceneManager->GetActiveScene());
+            GameGUI::GetInstance().Update(updateRate, sceneManager->GetActiveScene());
             UpgradeGUI::GetInstance().Update(updateRate, sceneManager->GetActiveScene());
         }
 


### PR DESCRIPTION
Game over shows:
-Level Reached
-Enemies Killed
-Time Played

Added console command
-"KillPlayer" Sets the players health to 0 and resulting in death
-"SkipLevel" Publish LevelDone event

Made GameGUI to a singleton to more easily access it in gameoverhandler. It was previously being used as a global variable in main only and suits well as a singleton.