### PR TITLE
Small Melee Attack Fix

### DIFF
--- a/StortSpelProjekt/Game/src/Gamefiles/Components/AiComponent.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/Components/AiComponent.cpp
@@ -504,15 +504,18 @@ void component::AiComponent::updateMelee(double dt)
 			HealthComponent* hc = m_pTarget->GetComponent<component::HealthComponent>();
 			if (hc != nullptr)
 			{
-				m_SpeedTimeAccumulator += static_cast<float>(dt);
-				if (m_SpeedTimeAccumulator >= m_AttackSpeed && m_IntervalTimeAccumulator >= m_AttackInterval)
+				if (m_IntervalTimeAccumulator >= m_AttackInterval)
 				{
-					m_pTarget->GetComponent<component::PlayerInputComponent>()->SetSlow(1.0f - m_SlowingAttack);
-					m_pTarget->GetComponent<component::HealthComponent>()->TakeDamage(m_MeleeAttackDmg);
-					m_pTarget->GetComponent<component::Audio2DVoiceComponent>()->Play(L"PlayerHit1");
-					Log::Print("ENEMY ATTACK!\n");
-					m_SpeedTimeAccumulator = 0.0;
-					m_IntervalTimeAccumulator = 0.0;
+					m_SpeedTimeAccumulator += static_cast<float>(dt);
+					if (m_SpeedTimeAccumulator >= m_AttackSpeed)
+					{
+						m_pTarget->GetComponent<component::PlayerInputComponent>()->SetSlow(1.0f - m_SlowingAttack);
+						m_pTarget->GetComponent<component::HealthComponent>()->TakeDamage(m_MeleeAttackDmg);
+						m_pTarget->GetComponent<component::Audio2DVoiceComponent>()->Play(L"PlayerHit1");
+						Log::Print("ENEMY ATTACK!\n");
+						m_SpeedTimeAccumulator = 0.0;
+						m_IntervalTimeAccumulator = 0.0;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
A small fix at a edge case. If the enemy attack and keeps within attacking distance, then both attack interval and attackspeed accumulators will count up causing the enemy to attack too fast.

Example.
Enemy has 0.5 seconds attack speed and 1.0 seconds attack interval
being equal to taking 1.5 seconds between attacks while in range equal to 0.666... attacks a second

Enemy Attacks taking 0.5 seconds
Enemy Waits 1.0 seconds for interval to regain while also getting attack speed
This causes the enemy to attack immediately skipping the attack speed timer.
This means the enemy can attack every second while in range giving 1 attack a second

With this fix:
The enemy attacks taking 0.5 seconds
The enemy waits 1.0 seconds to regain interval
The enemy attacks taking 0.5 seconds
The enemy now attacks every 1.5 seconds always giving 0.666 attacks a second always as intended.