### PR TITLE
Camera Stutter Fix

### DIFF
--- a/StortSpelProjekt/Engine/src/ECS/Components/TransformComponent.cpp
+++ b/StortSpelProjekt/Engine/src/ECS/Components/TransformComponent.cpp
@@ -25,7 +25,7 @@ namespace component
 
 	void TransformComponent::RenderUpdate(double dt)
 	{
-		m_pTransform->NormalizedMoveRender(dt);
+		m_pTransform->MoveRender(dt);
 		m_pTransform->UpdateWorldMatrix();
 	}
 

--- a/StortSpelProjekt/Engine/src/Renderer/Transform.cpp
+++ b/StortSpelProjekt/Engine/src/Renderer/Transform.cpp
@@ -60,6 +60,7 @@ void Transform::Move(float dt)
 	float moveY = m_Position.y + (m_Movement.y * m_Velocity * dt);
 	float moveZ = m_Position.z + (m_Movement.z * m_Velocity * dt);
 
+	m_OldPosition = m_Position;
 	m_Position = DirectX::XMFLOAT3(moveX, moveY, moveZ);
 	m_TimeBetweenFrame = 0;
 }
@@ -67,9 +68,9 @@ void Transform::Move(float dt)
 void Transform::MoveRender(float dt)
 {
 	m_TimeBetweenFrame += dt * m_UpdateRate;
-	float moveX = (1 - m_TimeBetweenFrame) * m_RenderPosition.x + m_TimeBetweenFrame * m_Position.x;
-	float moveY = (1 - m_TimeBetweenFrame) * m_RenderPosition.y + m_TimeBetweenFrame * m_Position.y;
-	float moveZ = (1 - m_TimeBetweenFrame) * m_RenderPosition.z + m_TimeBetweenFrame * m_Position.z;
+	float moveX = (1 - m_TimeBetweenFrame) * m_OldPosition.x + m_TimeBetweenFrame * m_Position.x;
+	float moveY = (1 - m_TimeBetweenFrame) * m_OldPosition.y + m_TimeBetweenFrame * m_Position.y;
+	float moveZ = (1 - m_TimeBetweenFrame) * m_OldPosition.z + m_TimeBetweenFrame * m_Position.z;
 
 	m_RenderPosition = DirectX::XMFLOAT3(moveX, moveY, moveZ);
 }
@@ -85,6 +86,7 @@ void Transform::NormalizedMove(float dt)
 	float moveY = m_Position.y + (normalizedMovement.y * m_Velocity * dt);
 	float moveZ = m_Position.z + (normalizedMovement.z * m_Velocity * dt);
 
+	m_OldPosition = m_Position;
 	m_Position = DirectX::XMFLOAT3(moveX, moveY, moveZ);
 	m_TimeBetweenFrame = 0;
 }

--- a/StortSpelProjekt/Engine/src/Renderer/Transform.h
+++ b/StortSpelProjekt/Engine/src/Renderer/Transform.h
@@ -101,6 +101,7 @@ private:
 	DirectX::XMMATRIX m_WorldMatTransposed;
 
 	DirectX::XMFLOAT3 m_Position;
+	DirectX::XMFLOAT3 m_OldPosition;
 	DirectX::XMFLOAT3 m_RenderPosition;
 	DirectX::XMFLOAT3 m_Movement;
 	DirectX::XMFLOAT3 m_Scale;

--- a/StortSpelProjekt/Engine/src/Renderer/Transform.h
+++ b/StortSpelProjekt/Engine/src/Renderer/Transform.h
@@ -112,6 +112,9 @@ private:
 
 	float m_Velocity;
 
+	double m_TimeBetweenFrame;
+	double m_UpdateRate;
+
 	int m_InvDir;
 };
 

--- a/StortSpelProjekt/Game/src/Gamefiles/Components/PlayerInputComponent.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/Components/PlayerInputComponent.cpp
@@ -138,6 +138,8 @@ void component::PlayerInputComponent::Update(double dt)
 			m_pCC->SetVelVector(move.x * speed, vel.y, move.z * speed);
 		}
 	}
+
+	updateCameraDirection();
 }
 
 void component::PlayerInputComponent::RenderUpdate(double dt)
@@ -149,8 +151,6 @@ void component::PlayerInputComponent::RenderUpdate(double dt)
 	// Lock camera to player
 	if (m_CameraFlags & CAMERA_FLAGS::USE_PLAYER_POSITION)
 	{
-		updateCameraDirection();
-
 		setCameraToPlayerPosition();
 
 		limitCameraDistance();
@@ -169,10 +169,6 @@ void component::PlayerInputComponent::RenderUpdate(double dt)
 			float angle = std::atan2(m_pTransform->GetInvDir() * vel.x, m_pTransform->GetInvDir() * vel.z);
 			m_pCC->SetRotation({ 0.0, 1.0, 0.0 }, angle);
 		}
-	}
-	else
-	{
-		updateCameraDirection();
 	}
 
 	/* ------------------ Increment timers -------------------- */


### PR DESCRIPTION
This feature fixes the camera stutter. This is done instead of removing renderupdate and keeping our current timestep solution. Because that is the proper and best way off handling timestep.

I also changed so renderPosition is linearly interpolated between update frames.