### PR TITLE
ASAP broken teleporter fix

### DIFF
--- a/StortSpelProjekt/Engine/src/ECS/Components/BoundingBoxComponent.cpp
+++ b/StortSpelProjekt/Engine/src/ECS/Components/BoundingBoxComponent.cpp
@@ -69,7 +69,7 @@ namespace component
 				obb.Orientation = m_OriginalBoundingBox.Orientation;
 
 				// then do all the transformations on this temoporary OBB so we don't change the original state
-				obb.Transform(obb, *m_Transforms[i]->GetWorldMatrix());
+				obb.Transform(obb, *m_Transforms[i]->GetLogicWorldMatrix());
 
 				// now save the transformations to the OBB that is used in collision detection
 				m_OrientedBoundingBox.Center = obb.Center;

--- a/StortSpelProjekt/Engine/src/ECS/Components/TransformComponent.cpp
+++ b/StortSpelProjekt/Engine/src/ECS/Components/TransformComponent.cpp
@@ -21,6 +21,7 @@ namespace component
 	void TransformComponent::Update(double dt)
 	{
 		m_pTransform->NormalizedMove(dt);
+		m_pTransform->UpdateLogicWorldMatrix();
 	}
 
 	void TransformComponent::RenderUpdate(double dt)

--- a/StortSpelProjekt/Engine/src/Renderer/Transform.cpp
+++ b/StortSpelProjekt/Engine/src/Renderer/Transform.cpp
@@ -36,6 +36,7 @@ void Transform::SetPosition(float x, float y, float z)
 void Transform::SetPosition(DirectX::XMFLOAT3 pos)
 {
 	m_Position = pos;
+	m_OldPosition = m_Position;
 	m_RenderPosition = pos;
 }
 
@@ -126,6 +127,15 @@ void Transform::IncreaseScaleByPercent(float scale)
 	m_Scale.z += m_Scale.z * scale;
 }
 
+void Transform::UpdateLogicWorldMatrix()
+{
+	DirectX::XMMATRIX posMat = DirectX::XMMatrixTranslation(m_Position.x, m_Position.y, m_Position.z);
+	DirectX::XMMATRIX sclMat = DirectX::XMMatrixScaling(m_Scale.x, m_Scale.y, m_Scale.z);
+	DirectX::XMMATRIX rotMat = m_RotationMat;
+
+	m_LogicWorldMat = sclMat * rotMat * posMat;
+}
+
 void Transform::UpdateWorldMatrix()
 {
 	DirectX::XMMATRIX posMat = DirectX::XMMatrixTranslation(m_RenderPosition.x, m_RenderPosition.y, m_RenderPosition.z);
@@ -136,6 +146,11 @@ void Transform::UpdateWorldMatrix()
 
 	// Update transposed world matrix
 	m_WorldMatTransposed = DirectX::XMMatrixTranspose(m_WorldMat);
+}
+
+DirectX::XMMATRIX* Transform::GetLogicWorldMatrix()
+{
+	return &m_LogicWorldMat;
 }
 
 DirectX::XMMATRIX* Transform::GetWorldMatrix()

--- a/StortSpelProjekt/Engine/src/Renderer/Transform.h
+++ b/StortSpelProjekt/Engine/src/Renderer/Transform.h
@@ -25,8 +25,6 @@ public:
 
 	// Moves the object in the direction of the current movement, but at the set speed. (Moves the object a maximum distance of the current speed * dt)
 	void NormalizedMove(float dt);
-	// Moves the object in the direction of the current movement, but at the set speed. (Moves the object a maximum distance of the current speed * dt)
-	void NormalizedMoveRender(float dt);
 	
 	void SetRotationX(float radians);
 	void SetRotationY(float radians);
@@ -36,8 +34,10 @@ public:
 	void SetScale(float x, float y, float z);
 	void IncreaseScaleByPercent(float scale);
 
+	void UpdateLogicWorldMatrix();
 	void UpdateWorldMatrix();
 
+	DirectX::XMMATRIX* GetLogicWorldMatrix();
 	DirectX::XMMATRIX* GetWorldMatrix();
 	DirectX::XMMATRIX* GetWorldMatrixTransposed();
 
@@ -97,6 +97,7 @@ public:
 	void UpdateActualMovement(float x, float y, float z);
 
 private:
+	DirectX::XMMATRIX m_LogicWorldMat;
 	DirectX::XMMATRIX m_WorldMat;
 	DirectX::XMMATRIX m_WorldMatTransposed;
 


### PR DESCRIPTION
A bug came in were sometimes the teleporter would not work in one way or another. Causing the player to constantly be sent back and forward until crash. Instantly sending the player back to shop or back to play map.

The problem was twofold. One oldposition was not defined and changed to position in SetPosition function. This caused it to be (0, 0, 0). Render position then sometimes interpolated between (0, 0, 0) and the set position.
Second problem WorldMatrix was using render position and was being used for handling collision. So sometimes the world position would sometimes be (0, 0, 0) when concering collision.