### PR TITLE
"Trying to remove entity ' ' that does not exist in scene" fix

### DIFF
--- a/StortSpelProjekt/Engine/src/ECS/SceneManager.cpp
+++ b/StortSpelProjekt/Engine/src/ECS/SceneManager.cpp
@@ -267,7 +267,20 @@ bool SceneManager::sceneExists(std::string sceneName) const
 
 void SceneManager::onEntityRemove(RemoveMe* evnt)
 {
-	m_ToRemove.push_back({ evnt->ent, m_pActiveScene });
+	// TODO: Ugly solution to a bug
+	bool entityWillBeRemoved = false;
+	for (auto& entity : m_ToRemove)
+	{
+		if (entity.ent == evnt->ent)
+		{
+			entityWillBeRemoved = true;
+		}
+	}
+
+	if (!entityWillBeRemoved)
+	{
+		m_ToRemove.push_back({ evnt->ent, m_pActiveScene });
+	}
 }
 
 void SceneManager::changeSceneNextFrame(SceneChange* sceneChangeEvent)

--- a/StortSpelProjekt/Engine/src/ECS/SceneManager.cpp
+++ b/StortSpelProjekt/Engine/src/ECS/SceneManager.cpp
@@ -274,6 +274,7 @@ void SceneManager::onEntityRemove(RemoveMe* evnt)
 		if (entity.ent == evnt->ent)
 		{
 			entityWillBeRemoved = true;
+			break;
 		}
 	}
 

--- a/StortSpelProjekt/Engine/src/ECS/SceneManager.cpp
+++ b/StortSpelProjekt/Engine/src/ECS/SceneManager.cpp
@@ -268,17 +268,17 @@ bool SceneManager::sceneExists(std::string sceneName) const
 void SceneManager::onEntityRemove(RemoveMe* evnt)
 {
 	// TODO: Ugly solution to a bug
-	bool entityWillBeRemoved = false;
+	bool entityIsAlreadyInTheVectorm_ToRemoveAndWillThereforeBeRemovedSoWeDoNotNeedToPushIt = false;
 	for (auto& entity : m_ToRemove)
 	{
 		if (entity.ent == evnt->ent)
 		{
-			entityWillBeRemoved = true;
+			entityIsAlreadyInTheVectorm_ToRemoveAndWillThereforeBeRemovedSoWeDoNotNeedToPushIt = true;
 			break;
 		}
 	}
 
-	if (!entityWillBeRemoved)
+	if (!entityIsAlreadyInTheVectorm_ToRemoveAndWillThereforeBeRemovedSoWeDoNotNeedToPushIt)
 	{
 		m_ToRemove.push_back({ evnt->ent, m_pActiveScene });
 	}


### PR DESCRIPTION
Fix to keep program from trying to remove an entity that has already been removed. Was caused by "RemoveMe" being sent several times by an entity in one frame. Fixed by checking if entity is already listed to be removed