### PR TITLE
Options menu volume change

### DIFF
--- a/StortSpelProjekt/Engine/src/AudioEngine/AudioBuffer.cpp
+++ b/StortSpelProjekt/Engine/src/AudioEngine/AudioBuffer.cpp
@@ -180,8 +180,6 @@ void AudioBuffer::OpenFile(IXAudio2* pXAudio2, const std::wstring& path)
     m_pSourceVoice->FlushSourceBuffers();
     m_pSourceVoice->SubmitSourceBuffer(&m_Buffer);
 
-    m_pSourceVoice->SetVolume(std::atof(Option::GetInstance().GetVariable("f_volume").c_str()));
-
     CloseHandle(hFile);
 
     remove("DecryptedWav.wav");

--- a/StortSpelProjekt/Engine/src/AudioEngine/AudioEngine.cpp
+++ b/StortSpelProjekt/Engine/src/AudioEngine/AudioEngine.cpp
@@ -1,4 +1,5 @@
 #include "AudioEngine.h"
+#include "../Misc/Option.h"
 
 AudioEngine::AudioEngine()
 {
@@ -24,6 +25,8 @@ AudioEngine::AudioEngine()
 	// debug info
 	//m_AudioDebugInfo.TraceMask = XAUDIO2_LOG_ERRORS;
 	m_pXAudio2->SetDebugConfiguration(&m_AudioDebugInfo);
+
+	m_pMasterVoice->SetVolume(std::atof(Option::GetInstance().GetVariable("f_masterVolume").c_str()));;
 }
 
 AudioEngine& AudioEngine::GetInstance()
@@ -66,4 +69,9 @@ void AudioEngine::SetListenerPtr(X3DAUDIO_LISTENER* listener)
 X3DAUDIO_LISTENER* AudioEngine::GetListener()
 {
 	return m_pListener;
+}
+
+void AudioEngine::ChangeMasterVolume(float vol)
+{
+	m_pMasterVoice->SetVolume(vol);
 }

--- a/StortSpelProjekt/Engine/src/AudioEngine/AudioEngine.h
+++ b/StortSpelProjekt/Engine/src/AudioEngine/AudioEngine.h
@@ -4,6 +4,9 @@
 #include <x3daudio.h>
 #pragma comment(lib, "xaudio2")
 
+#define VOLUME3D 1.0
+#define VOLUME2D 0.2
+
 class AudioEngine
 {
 public:

--- a/StortSpelProjekt/Engine/src/AudioEngine/AudioEngine.h
+++ b/StortSpelProjekt/Engine/src/AudioEngine/AudioEngine.h
@@ -16,6 +16,7 @@ public:
 	XAUDIO2_VOICE_DETAILS* GetDeviceDetails();
 	void SetListenerPtr(X3DAUDIO_LISTENER* listener);
 	X3DAUDIO_LISTENER* GetListener();
+	void ChangeMasterVolume(float vol);
 
 private:
 	AudioEngine();

--- a/StortSpelProjekt/Engine/src/AudioEngine/AudioVoice.cpp
+++ b/StortSpelProjekt/Engine/src/AudioEngine/AudioVoice.cpp
@@ -32,7 +32,6 @@ void AudioVoice::initialize(XAUDIO2_BUFFER* buff, WAVEFORMATEXTENSIBLE* wfxForma
         Log::Print("Failed to submit source buffer\n");
     }
 
-    m_pSourceVoice->SetVolume(std::atof(Option::GetInstance().GetVariable("f_volume").c_str()));
     HRESULT hRes = m_pSourceVoice->SetOutputVoices(NULL);
 
     Stop();

--- a/StortSpelProjekt/Engine/src/ECS/Components/Audio2DVoiceComponent.cpp
+++ b/StortSpelProjekt/Engine/src/ECS/Components/Audio2DVoiceComponent.cpp
@@ -46,8 +46,8 @@ void component::Audio2DVoiceComponent::AddVoice(const std::wstring& name)
 		if (clonedVoice.GetSourceVoice() != nullptr)
 		{
 			m_Voices.insert(std::make_pair(name, AssetLoader::Get()->GetAudio(name)->CloneVoice()));
-			// Lower the volume of background sound, so 3d sound can be heard in test scene.
-			m_Voices[name].GetSourceVoice()->SetVolume(std::atof(Option::GetInstance().GetVariable("f_backgroundVolume").c_str()));
+			// Lower the volume of background sounds, so it doesn't drown out 3d sounds
+			m_Voices[name].GetSourceVoice()->SetVolume(VOLUME2D);
 		}
 	}
 }

--- a/StortSpelProjekt/Engine/src/ECS/Components/Audio3DEmitterComponent.cpp
+++ b/StortSpelProjekt/Engine/src/ECS/Components/Audio3DEmitterComponent.cpp
@@ -105,6 +105,7 @@ void component::Audio3DEmitterComponent::AddVoice(const std::wstring& name)
 			emitterData.DSPSettings.DstChannelCount = AudioEngine::GetInstance().GetDeviceDetails()->InputChannels;
 			int coefficients = emitterData.DSPSettings.SrcChannelCount * emitterData.DSPSettings.DstChannelCount;
 			emitterData.DSPSettings.pMatrixCoefficients = new FLOAT32[coefficients];
+			emitterData.voice.GetSourceVoice()->SetVolume(VOLUME3D);
 
 			// put emitterData struct in the map with key
 			m_VoiceEmitterData.emplace(std::make_pair(name, emitterData));
@@ -137,6 +138,7 @@ void component::Audio3DEmitterComponent::AddVoice(const std::wstring& globalName
 			emitterData.DSPSettings.DstChannelCount = AudioEngine::GetInstance().GetDeviceDetails()->InputChannels;
 			int coefficients = emitterData.DSPSettings.SrcChannelCount * emitterData.DSPSettings.DstChannelCount;
 			emitterData.DSPSettings.pMatrixCoefficients = new FLOAT32[coefficients];
+			emitterData.voice.GetSourceVoice()->SetVolume(VOLUME3D);
 
 			// put emitterData struct in the map with key
 			m_VoiceEmitterData.emplace(std::make_pair(localName, emitterData));

--- a/StortSpelProjekt/Engine/src/ECS/SceneManager.cpp
+++ b/StortSpelProjekt/Engine/src/ECS/SceneManager.cpp
@@ -32,6 +32,9 @@
 #include "../ECS/Components/Lights/SpotLightComponent.h"
 #include "../ECS/Entity.h"
 
+// Options
+#include "../Misc/Option.h"
+
 SceneManager::SceneManager()
 {
 	EventBus::GetInstance().Subscribe(this, &SceneManager::onEntityRemove);
@@ -138,7 +141,10 @@ bool SceneManager::ChangeScene()
 		if (scene->GetName() == "MainMenuScene" || scene->GetName() == "OptionScene")
 		{
 			component::Audio2DVoiceComponent* vc = scene->GetEntity("player")->GetComponent<component::Audio2DVoiceComponent>();
-			vc->Play(L"MenuMusic");
+			if (std::atof(Option::GetInstance().GetVariable("i_music").c_str()))
+			{
+				vc->Play(L"MenuMusic");
+			}
 		}
 
 		m_ChangeSceneNextFrame = false;

--- a/StortSpelProjekt/Game/src/Gamefiles/GameGUI.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/GameGUI.cpp
@@ -67,7 +67,7 @@ void GameGUI::Update(double dt, Scene* scene)
 		entity->GetComponent<component::GUI2DComponent>()->GetTextManager()->SetText(Option::GetInstance().GetVariable("f_brightness"), "brightness");
 
 		entity = scene->GetEntity("volume");
-		entity->GetComponent<component::GUI2DComponent>()->GetTextManager()->SetText(Option::GetInstance().GetVariable("f_volume"), "volume");
+		entity->GetComponent<component::GUI2DComponent>()->GetTextManager()->SetText(Option::GetInstance().GetVariable("f_masterVolume"), "volume");
 
 		entity = scene->GetEntity("MouseSensitivity");
 		entity->GetComponent<component::GUI2DComponent>()->GetTextManager()->SetText(Option::GetInstance().GetVariable("f_sensitivityX"), "MouseSensitivity");

--- a/StortSpelProjekt/Game/src/Gamefiles/MainMenuHandler.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/MainMenuHandler.cpp
@@ -413,7 +413,7 @@ void MainMenuHandler::createOptionScene()
         minus);
     guic->GetQuadManager()->SetOnClicked(&onVolumeMinus);
 
-    textToRender = Option::GetInstance().GetVariable("f_volume");
+    textToRender = Option::GetInstance().GetVariable("f_masterVolume");
     textPos = { 0.7f, 0.52f };
     textPadding = { 0.5f, 0.0f };
     textColor = { 1.0f, 1.0f, 1.0f, 1.0f };
@@ -713,7 +713,10 @@ Scene* MainMenuHandler::GetScene()
 
 void onMainMenuSceneInit(Scene* scene)
 {
-    scene->GetEntity("player")->GetComponent<component::Audio2DVoiceComponent>()->Play(L"MenuMusic");
+    if (std::atof(Option::GetInstance().GetVariable("i_music").c_str()))
+    {
+        scene->GetEntity("player")->GetComponent<component::Audio2DVoiceComponent>()->Play(L"MenuMusic");
+    }
 }
 
 void onBrightnessPlus(const std::string& name)
@@ -909,25 +912,27 @@ void onHighShadowQuality(const std::string& name)
 
 void onVolumePlus(const std::string& name)
 {
-    if (std::stof(Option::GetInstance().GetVariable("f_volume")) < 10)
+    if (std::stof(Option::GetInstance().GetVariable("f_masterVolume")) < 10)
     {
         std::ostringstream str;
-        str << std::fixed << std::setprecision(1) << std::stof(Option::GetInstance().GetVariable("f_volume")) + 0.1f;
-        Option::GetInstance().SetVariable("f_volume", str.str());
+        str << std::fixed << std::setprecision(1) << std::stof(Option::GetInstance().GetVariable("f_masterVolume")) + 0.1f;
+        Option::GetInstance().SetVariable("f_masterVolume", str.str());
 
         Option::GetInstance().WriteFile();
+        AudioEngine::GetInstance().ChangeMasterVolume(std::stof(str.str()));
     }
 }
 
 void onVolumeMinus(const std::string& name)
 {
-    if (std::stof(Option::GetInstance().GetVariable("f_volume")) > 0)
+    if (std::stof(Option::GetInstance().GetVariable("f_masterVolume")) > 0)
     {
         std::ostringstream str;
-        str << std::fixed << std::setprecision(1) << std::stof(Option::GetInstance().GetVariable("f_volume")) - 0.1f;
-        Option::GetInstance().SetVariable("f_volume", str.str());
+        str << std::fixed << std::setprecision(1) << std::stof(Option::GetInstance().GetVariable("f_masterVolume")) - 0.1f;
+        Option::GetInstance().SetVariable("f_masterVolume", str.str());
 
         Option::GetInstance().WriteFile();
+        AudioEngine::GetInstance().ChangeMasterVolume(std::stof(str.str()));
     }
 }
 

--- a/StortSpelProjekt/Game/src/Gamefiles/MainMenuHandler.cpp
+++ b/StortSpelProjekt/Game/src/Gamefiles/MainMenuHandler.cpp
@@ -942,6 +942,15 @@ void onBox(const std::string& name)
 	Option::GetInstance().SetVariable("i_music", std::to_string(!active));
 	Option::GetInstance().WriteFile();
 
+    if (std::atof(Option::GetInstance().GetVariable("i_music").c_str()))
+    {
+        SceneManager::GetInstance().GetActiveScene()->GetEntity("player")->GetComponent<component::Audio2DVoiceComponent>()->Play(L"MenuMusic");
+    }
+    else
+    {
+        SceneManager::GetInstance().GetActiveScene()->GetEntity("player")->GetComponent<component::Audio2DVoiceComponent>()->Stop(L"MenuMusic");
+    }
+    
 	float4 blended = { 1.0, 1.0, 1.0, 1.0 };
 	if (active)
 	{

--- a/StortSpelProjekt/Vendor/config.txt
+++ b/StortSpelProjekt/Vendor/config.txt
@@ -1,3 +1,4 @@
+f_masterVolume 1.0
 f_volume 1.0
 f_backgroundVolume 0.2
 f_updateRate 30

--- a/StortSpelProjekt/Vendor/config.txt
+++ b/StortSpelProjekt/Vendor/config.txt
@@ -1,6 +1,4 @@
 f_masterVolume 1.0
-f_volume 1.0
-f_backgroundVolume 0.2
 f_updateRate 30
 f_networkUpdateRate 15
 i_resolutionWidth 1920


### PR DESCRIPTION
Made the volume option to change master volume instead of only the 3d sounds. Now when volume is 0 you will hear nothing (before you would still hear 2d sounds). The volume changes also don't require game restart anymore. 
The music option will now also stop the menu music when unchecked.